### PR TITLE
:x: Removed `poetry` command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The TFL CLI provides a command line interface to the TFL API. It is built on top
 [Typer](https://typer.tiangolo.com/), which provides easy way to build command line interfaces.
 
 ```bash
-poetry run tfl --help
+tfl --help
 ```
 
 ### 🦋 Client

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ The TFL CLI provides a command line interface to the TFL API. It is built on top
 [Typer](https://typer.tiangolo.com/), which provides easy way to build command line interfaces.
 
 ```bash
-poetry run tfl --help
+tfl --help
 ```
 
 ### 🦋 Client


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

<!-- Provide information on the motivation for why you have made this change. -->

Now that the package can be installed via `pip` there is no need for the `poetry` command in the documentation.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
